### PR TITLE
docs: add documentation URL to manifest

### DIFF
--- a/custom_components/sunEnergyXT/manifest.json
+++ b/custom_components/sunEnergyXT/manifest.json
@@ -5,11 +5,11 @@
   "config_flow": true,
   "integration_type": "device",
   "iot_class": "local_polling",
-  "documentation": "",
+  "documentation": "https://www.sunenergyxt.com/entdecken/steuerung/home-assistant/how-to-integrate-your-BK215-BK215Plus-with-home-assistant",
   "issue_tracker": "",
   "quality_scale": "custom",
   "dependencies": ["network", "dhcp","zeroconf"],
   "requirements": ["propcache", "aiofiles", "pyyaml"],
   "translations": ["translations"],
-  "version": "26.01.19"
+  "version": "26.01.20"
 }


### PR DESCRIPTION
## Summary
This pull request adds the official Home Assistant documentation URL to the integration’s `manifest.json`.

Providing a documentation link improves the user experience for Home Assistant and HACS users by making setup and usage instructions easily accessible.

## Changes
- Added `documentation` field to `manifest.json`
- Linked to the official SunEnergyXT Home Assistant integration documentation

## Motivation
- Improves usability for Home Assistant users
- Aligns the integration with Home Assistant and HACS metadata requirements
- Reduces confusion and unnecessary support requests

## Scope
- Metadata only
- No functional or runtime changes

## Checklist
- [x] No functional behavior changed
- [x] Metadata-only change
- [x] Backward compatible
- [x] No breaking changes
